### PR TITLE
Automate publish to npm

### DIFF
--- a/.github/npm-publish.yml
+++ b/.github/npm-publish.yml
@@ -1,0 +1,35 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: ['14']
+
+    name: node${{ matrix.node-version }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up node ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies & build
+        run: |
+          npm ci
+          npm run build --if-present
+
+      - name: Publish to npm
+        run: |
+          npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Add a workflow to publish this package to npm on release, also needs an `NPM_TOKEN` secret :)

Similar to the workflows as seen in the [eslint-config](https://github.com/nextcloud/eslint-config/blob/master/.github/workflows/npm-publish.yml) and [webpack-vue-config](https://github.com/nextcloud/webpack-vue-config/blob/master/.github/workflows/npm-publish.yml) repos.