### PR TITLE
Hide error message when reconfirming password and update message

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -6,12 +6,12 @@ msgstr ""
 msgid "Authentication required"
 msgstr ""
 
-#: src/components/Dialog.vue:86
+#: src/components/Dialog.vue:87
 msgid "Confirm"
 msgstr ""
 
-#: src/components/Dialog.vue:105
-msgid "Failed to authenticate, try again"
+#: src/components/Dialog.vue:86
+msgid "Failed to authenticate, please try again"
 msgstr ""
 
 #: src/components/Dialog.vue:85

--- a/src/components/Dialog.vue
+++ b/src/components/Dialog.vue
@@ -37,9 +37,9 @@
         @invalid="valid = false"
         @keydown.enter="confirm" />
 
-      <NcNoteCard v-if="errorMessage"
+      <NcNoteCard v-if="showError"
         :show-alert="true">
-        <p>{{ errorMessage }}</p>
+        <p>{{ errorText }}</p>
       </NcNoteCard>
 
       <NcButton type="primary"
@@ -77,12 +77,13 @@ export default Vue.extend({
   data() {
     return {
       password: '',
-      errorMessage: '',
+      showError: false,
       valid: Boolean((getCapabilities() as any)?.password_policy) ? false : true,
       dialogId: DIALOG_ID,
       titleText: t('Authentication required'),
       subtitleText: t('This action requires you to confirm your password'),
       passwordLabelText: t('Password'),
+      errorText: t('Failed to authenticate, please try again'),
       confirmText: t('Confirm'),
     }
   },
@@ -95,14 +96,15 @@ export default Vue.extend({
 
   methods: {
     async confirm(): Promise<void> {
+      this.showError = false
+
       const url = generateUrl('/login/confirm')
       try {
         const { data } = await axios.post(url, { password: this.password })
         window.nc_lastLogin = data.lastLogin
-        this.errorMessage = ''
         this.$emit('confirmed')
       } catch (e) {
-        this.errorMessage = t('Failed to authenticate, try again')
+        this.showError = true
       }
     },
 


### PR DESCRIPTION
After failing to authenticate the first time, hide the error while the new confirmation request is pending