### PR TITLE
Fix dialog not appearing when another modal is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Fix dialog not appearing when another modal is open
+
 ## 3.0.0 - 2022-09-07
 
 ### Breaking

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -2,19 +2,19 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: src/components/Dialog.vue:83
+#: src/components/Dialog.vue:84
 msgid "Authentication required"
 msgstr ""
 
-#: src/components/Dialog.vue:87
+#: src/components/Dialog.vue:88
 msgid "Confirm"
 msgstr ""
 
-#: src/components/Dialog.vue:86
+#: src/components/Dialog.vue:87
 msgid "Failed to authenticate, please try again"
 msgstr ""
 
-#: src/components/Dialog.vue:85
+#: src/components/Dialog.vue:86
 msgid "Password"
 msgstr ""
 
@@ -22,6 +22,6 @@ msgstr ""
 msgid "Password confirmation dialog already mounted"
 msgstr ""
 
-#: src/components/Dialog.vue:84
+#: src/components/Dialog.vue:85
 msgid "This action requires you to confirm your password"
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@nextcloud/capabilities": "^1.0.4",
         "@nextcloud/l10n": "^1.6.0",
         "@nextcloud/router": "^2.0.0",
-        "@nextcloud/vue": "^7.0.0-beta.0",
+        "@nextcloud/vue": "^7.0.0-beta.2",
         "vue": "^2.7.10"
       },
       "devDependencies": {
@@ -268,9 +268,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "7.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.0-beta.1.tgz",
-      "integrity": "sha512-kPfB0EJVm9LbYntiLIF9JamL7rj8f0jej52oM7x+wNti1K/bmwe3WHTZE+T0zpKR2WKe5eMRURrWUjJ1cH3wfw==",
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.0-beta.2.tgz",
+      "integrity": "sha512-DD2Vhh7YxzJmcjuOM4E51VsHDiAFZqZT5tNaMKr/UFeSnA3p859fRHcmwmWwQgnvZbiaHJE+mzJFTYYCWhPQ0Q==",
       "dependencies": {
         "@nextcloud/auth": "^2.0.0",
         "@nextcloud/axios": "^2.0.0",
@@ -2746,9 +2746,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "7.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.0-beta.1.tgz",
-      "integrity": "sha512-kPfB0EJVm9LbYntiLIF9JamL7rj8f0jej52oM7x+wNti1K/bmwe3WHTZE+T0zpKR2WKe5eMRURrWUjJ1cH3wfw==",
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.0-beta.2.tgz",
+      "integrity": "sha512-DD2Vhh7YxzJmcjuOM4E51VsHDiAFZqZT5tNaMKr/UFeSnA3p859fRHcmwmWwQgnvZbiaHJE+mzJFTYYCWhPQ0Q==",
       "requires": {
         "@nextcloud/auth": "^2.0.0",
         "@nextcloud/axios": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@nextcloud/capabilities": "^1.0.4",
     "@nextcloud/l10n": "^1.6.0",
     "@nextcloud/router": "^2.0.0",
-    "@nextcloud/vue": "^7.0.0-beta.0",
+    "@nextcloud/vue": "^7.0.0-beta.2",
     "vue": "^2.7.10"
   },
   "devDependencies": {

--- a/src/components/Dialog.vue
+++ b/src/components/Dialog.vue
@@ -24,6 +24,7 @@
   <NcModal :id="dialogId"
     class="dialog"
     size="small"
+    :container="null"
     @close="close">
     <div class="dialog__container">
       <h2 class="dialog__title">{{ titleText }}</h2>

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,1 +1,2 @@
 export const DIALOG_ID = 'password-confirmation-dialog'
+export const MODAL_CLASS = 'modal-mask' // NcModal component root class https://github.com/nextcloud/nextcloud-vue/blob/v7.0.0-beta.2/src/components/NcModal/NcModal.vue

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import DialogComponent from './components/Dialog.vue'
-import { DIALOG_ID } from './globals.js'
+import { DIALOG_ID, MODAL_CLASS } from './globals.js'
 import { t } from './utils/l10n.js'
 
 import type { ComponentInstance } from 'vue'
@@ -27,7 +27,16 @@ export const confirmPassword = (): Promise<void> => {
 
   const mountPoint = document.createElement('div')
   mountPoint.setAttribute('id', DIALOG_ID)
-  document.body.prepend(mountPoint)
+
+  const modals = document.querySelectorAll(`.${MODAL_CLASS}`)
+  const isModalMounted = Boolean(modals.length)
+
+  if (isModalMounted) {
+    const previousModal = modals[modals.length - 1]
+    previousModal.prepend(mountPoint)
+  } else {
+    document.body.prepend(mountPoint)
+  }
 
   const DialogClass = Vue.extend(DialogComponent)
   // Mount point element is replaced by the component


### PR DESCRIPTION
Fix dialog not appearing from the infinite focus trap loop due to the dialog and modal being mounted as siblings instead of being nested as described in https://github.com/tailwindlabs/headlessui/issues/825#issuecomment-927182208

The solution is to mount the dialog within the existing modal

Prepending to the previous modal is not enough as NcModal automatically remounts itself to `document.body` by default https://github.com/nextcloud/nextcloud-vue/blob/v7.0.0-beta.2/src/components/NcModal/NcModal.vue#L555-L561

So to prevent automatic mounting in NcModal `null` is passed to the `container` prop

This will show errors in the console that can be dismissed as it has no effect other than preventing automatic remounting but is addressed in https://github.com/nextcloud/nextcloud-vue/pull/3219