### PR TITLE
Remove exports field to fix eslint and build errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Breaking
+
+- Dialog styles must be imported with `import '@nextcloud/password-confirmation/dist/style.css'`
+
+### Fixed
+
+- Remove exports field to fix eslint and build errors in dependent environments
+
 ## 3.0.1 - 2022-09-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm add @nextcloud/password-confirmation
 ## Usage
 ```js
 import { confirmPassword } from '@nextcloud/password-confirmation'
-import '@nextcloud/password-confirmation/style.css' // Required for dialog styles
+import '@nextcloud/password-confirmation/dist/style.css' // Required for dialog styles
 
 const foo = async () => {
     try {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,6 @@
   "main": "./dist/main.js",
   "browser": "./dist/main.js",
   "types": "./dist/main.d.ts",
-  "exports": {
-    ".": "./dist/main.js",
-    "./style.css": "./dist/style.css"
-  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Fix errors in https://github.com/nextcloud/server/pull/34044

The eslint errors `import/no-unresolved` and `node/no-missing-import` are due to the lack of support for the [`exports`](https://nodejs.org/api/packages.html#package-entry-points) field, see https://github.com/import-js/eslint-plugin-import/issues/1810 and https://github.com/mysticatea/eslint-plugin-node/issues/255

Switching from
```js
import '@nextcloud/password-confirmation/style.css'
```
to
```js
import '@nextcloud/password-confirmation/dist/style.css'
```
fixes the eslint errors but results in new build errors coming from `babel-loader`
```
Module not found: Error: Package path ./dist/style.css is not exported from package <path>/node_modules/@nextcloud/password-confirmation (see exports field in <path>/node_modules/@nextcloud/password-confirmation/package.json)
```

This seems to be because `babel-loader` uses the `exports` field exclusively when present

So switching to the `dist` import in https://github.com/nextcloud/server/pull/34044 and removing the `exports` field in this package is needed to resolve the errors