### PR TITLE
Remove password policy checks completely to fix permanently disabled confirm button

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -2,19 +2,19 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: src/components/Dialog.vue:84
+#: src/components/Dialog.vue:78
 msgid "Authentication required"
 msgstr ""
 
-#: src/components/Dialog.vue:88
+#: src/components/Dialog.vue:82
 msgid "Confirm"
 msgstr ""
 
-#: src/components/Dialog.vue:87
+#: src/components/Dialog.vue:81
 msgid "Failed to authenticate, please try again"
 msgstr ""
 
-#: src/components/Dialog.vue:86
+#: src/components/Dialog.vue:80
 msgid "Password"
 msgstr ""
 
@@ -22,6 +22,6 @@ msgstr ""
 msgid "Password confirmation dialog already mounted"
 msgstr ""
 
-#: src/components/Dialog.vue:85
+#: src/components/Dialog.vue:79
 msgid "This action requires you to confirm your password"
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@nextcloud/axios": "^2.0.0",
-        "@nextcloud/capabilities": "^1.0.4",
         "@nextcloud/l10n": "^1.6.0",
         "@nextcloud/router": "^2.0.0",
         "@nextcloud/vue": "^7.0.0-beta.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "license": "MIT",
   "dependencies": {
     "@nextcloud/axios": "^2.0.0",
-    "@nextcloud/capabilities": "^1.0.4",
     "@nextcloud/l10n": "^1.6.0",
     "@nextcloud/router": "^2.0.0",
     "@nextcloud/vue": "^7.0.0-beta.5",

--- a/src/components/Dialog.vue
+++ b/src/components/Dialog.vue
@@ -33,9 +33,6 @@
       <NcPasswordField ref="field"
         :value.sync="password"
         :label="passwordLabelText"
-        :check-password-strength="false"
-        @valid="valid = true"
-        @invalid="valid = false"
         @keydown.enter="confirm" />
 
       <NcNoteCard v-if="showError"
@@ -46,7 +43,6 @@
       <NcButton type="primary"
         class="dialog__button"
         :aria-label="confirmText"
-        :disabled="!valid"
         @click="confirm">
         {{ confirmText }}
       </NcButton>
@@ -58,7 +54,6 @@
 import Vue from 'vue'
 import axios from '@nextcloud/axios'
 import { NcButton, NcModal, NcNoteCard, NcPasswordField } from '@nextcloud/vue'
-import { getCapabilities } from '@nextcloud/capabilities'
 import { generateUrl } from '@nextcloud/router'
 import { DIALOG_ID } from '../globals.js'
 import { t } from '../utils/l10n.js'
@@ -79,7 +74,6 @@ export default Vue.extend({
     return {
       password: '',
       showError: false,
-      valid: Boolean((getCapabilities() as any)?.password_policy) ? false : true,
       dialogId: DIALOG_ID,
       titleText: t('Authentication required'),
       subtitleText: t('This action requires you to confirm your password'),


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/34217

Simpler in the end to just not use the built-in password policy checks from `NcPasswordField`

Addendum to https://github.com/nextcloud/nextcloud-password-confirmation/pull/399