### PR TITLE
Fix badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # @nextcloud/password-confirmation
 
 [![npm](https://img.shields.io/npm/v/@nextcloud/password-confirmation?style=for-the-badge)](https://www.npmjs.com/package/@nextcloud/password-confirmation)
-[![Build Status](https://img.shields.io/github/workflow/status/nextcloud/nextcloud-password-confirmation/Node?label=Build&style=for-the-badge)](https://github.com/nextcloud/nextcloud-password-confirmation/actions)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/nextcloud/nextcloud-password-confirmation/node.yml?branch=master&label=Build&style=for-the-badge)](https://github.com/nextcloud/nextcloud-password-confirmation/actions?query=branch%3Amaster)
+[![License](https://img.shields.io/github/license/nextcloud/nextcloud-password-confirmation?style=for-the-badge)](https://github.com/nextcloud/nextcloud-password-confirmation/blob/master/LICENSE)
 
 Promise-based password confirmation for Nextcloud.
 


### PR DESCRIPTION
before | after
---|---
![image](https://user-images.githubusercontent.com/1855448/219412576-bc176bf1-3b1b-45e9-8f2c-4a718a428cab.png) | ![image](https://user-images.githubusercontent.com/1855448/219412606-1ab57a43-7281-4332-bd40-7e8188a044fa.png)

Fix changed URL for github action status badge